### PR TITLE
Use occam.Source in integration tests.

### DIFF
--- a/integration/default_test.go
+++ b/integration/default_test.go
@@ -39,6 +39,9 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "default_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -50,8 +53,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 
 		it("builds an oci image that has the correct behavior", func() {
 			var err error
-			source, err = occam.Source(filepath.Join("testdata", "default_app"))
-			Expect(err).NotTo(HaveOccurred())
 
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
@@ -85,6 +86,9 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 				sbomDir, err = os.MkdirTemp("", "sbom")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(os.Chmod(sbomDir, os.ModePerm)).To(Succeed())
+
+				source, err = occam.Source(filepath.Join("testdata", "vendored_app"))
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			it.After(func() {
@@ -94,9 +98,6 @@ func testDefault(t *testing.T, context spec.G, it spec.S) {
 			it("writes SBOM files to the layer and label metadata", func() {
 				var err error
 				var logs fmt.Stringer
-
-				source, err = occam.Source(filepath.Join("testdata", "vendored_app"))
-				Expect(err).NotTo(HaveOccurred())
 
 				image, logs, err = pack.WithNoColor().Build.
 					WithPullPolicy("never").

--- a/integration/layer_reuse_test.go
+++ b/integration/layer_reuse_test.go
@@ -45,6 +45,9 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 
 			imagesMap = map[string]interface{}{}
 			containerMap = map[string]interface{}{}
+
+			source, err = occam.Source(filepath.Join("testdata", "with_lock_file"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -62,8 +65,6 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 		context("when the app has a lockfile and there are no changes between builds", func() {
 			it("reuses the cached packages layer", func() {
 				var err error
-				source, err = occam.Source(filepath.Join("testdata", "with_lock_file"))
-				Expect(err).NotTo(HaveOccurred())
 
 				var logs fmt.Stringer
 				firstImage, logs, err = pack.WithNoColor().Build.
@@ -121,10 +122,14 @@ func testLayerReuse(t *testing.T, context spec.G, it spec.S) {
 		})
 
 		context("the app contains no lock file but there are no changes between builds", func() {
-			it("DOES NOT reuse the cached packages layer", func() {
+			it.Before(func() {
 				var err error
 				source, err = occam.Source(filepath.Join("testdata", "default_app"))
 				Expect(err).NotTo(HaveOccurred())
+			})
+
+			it("DOES NOT reuse the cached packages layer", func() {
+				var err error
 
 				var logs fmt.Stringer
 				firstImage, logs, err = pack.WithNoColor().Build.

--- a/integration/lock_file_test.go
+++ b/integration/lock_file_test.go
@@ -39,6 +39,9 @@ func testLockFile(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "with_lock_file"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -51,8 +54,6 @@ func testLockFile(t *testing.T, context spec.G, it spec.S) {
 
 		it("installs dependencies in the app image based on the lock file", func() {
 			var err error
-			source, err = occam.Source(filepath.Join("testdata", "with_lock_file"))
-			Expect(err).NotTo(HaveOccurred())
 
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.

--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -152,6 +152,5 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				"",
 			))
 		})
-
 	})
 }

--- a/integration/offline_test.go
+++ b/integration/offline_test.go
@@ -38,6 +38,9 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 			var err error
 			name, err = occam.RandomName()
 			Expect(err).NotTo(HaveOccurred())
+
+			source, err = occam.Source(filepath.Join("testdata", "vendored_app"))
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		it.After(func() {
@@ -49,8 +52,6 @@ func testOffline(t *testing.T, context spec.G, it spec.S) {
 
 		it("uses the vendored dependencies for the build", func() {
 			var err error
-			source, err = occam.Source(filepath.Join("testdata", "vendored_app"))
-			Expect(err).NotTo(HaveOccurred())
 
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.


### PR DESCRIPTION
## Summary

This PR ensures that each test uses `occam.Source` in a consistent manner. This ensures that we do not accidentally re-use images across tests.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
