### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Paketo Conda Env Update Cloud Native Buildpack
+# Paketo Buildpack for Conda Env Update Cloud Native
 
 The Conda Env Update Buildpack runs commands to update the conda environment. It installs the conda environment into a
 layer which makes it available for subsequent buildpacks and in the final running container.

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -3,7 +3,7 @@ api = "0.7"
 [buildpack]
   homepage = "https://github.com/paketo-buildpacks/conda-env-update"
   id = "paketo-buildpacks/conda-env-update"
-  name = "Paketo Conda Env Update Buildpack"
+  name = "Paketo Buildpack for Conda Env Update"
   sbom-formats = ["application/vnd.cyclonedx+json", "application/spdx+json", "application/vnd.syft+json"]
 
   [[buildpack.licenses]]


### PR DESCRIPTION
Renames 'Paketo Conda Env Update Buildpack' to 'Paketo Buildpack for Conda Env Update'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
