### PR TITLE
Bumps Eventually timeout in the integration suite

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -39,6 +39,7 @@ func TestIntegration(t *testing.T) {
 	// Do not truncate Gomega matcher output
 	// The buildpack output text can be large and we often want to see all of it.
 	format.MaxLength = 0
+	SetDefaultEventuallyTimeout(10 * time.Second)
 
 	Expect := NewWithT(t).Expect
 


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Doubles the default timeout for `Eventually` in the integration suite.

## Use Cases
<!-- An explanation of the use cases your change enables -->
The last three failures on this issue are timeouts in the test suite: https://github.com/paketo-buildpacks/conda-env-update/issues/141

- https://github.com/paketo-buildpacks/conda-env-update/runs/7774011755?check_suite_focus=true#step:5:315
- https://github.com/paketo-buildpacks/conda-env-update/runs/7774328282?check_suite_focus=true#step:5:317
- https://github.com/paketo-buildpacks/conda-env-update/runs/8149731710?check_suite_focus=true#step:5:318

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
