### PR TITLE
Remove conda history file.

### DIFF
--- a/integration/logging_test.go
+++ b/integration/logging_test.go
@@ -68,8 +68,14 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				fmt.Sprintf("    Running conda create --file /workspace/package-list.txt --prefix /layers/%s/conda-env --yes --quiet --channel /workspace/vendor --override-channels --offline",
-					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+				fmt.Sprintf(
+					"    Running conda create --file /workspace/package-list.txt --prefix /layers/%s/conda-env --yes --quiet --channel /workspace/vendor --override-channels --offline",
+					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"),
+				),
+				fmt.Sprintf(
+					"    Removing /layers/%s/conda-env/conda-meta/history",
+					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"),
+				),
 				MatchRegexp(`      Completed in (\d+m)?(\d+)(\.\d+)?(ms|s)`),
 				"",
 			))
@@ -97,9 +103,16 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				MatchRegexp(fmt.Sprintf(`%s \d+\.\d+\.\d+`, buildpackInfo.Buildpack.Name)),
 				"  Executing build process",
-				fmt.Sprintf("    Running CONDA_PKGS_DIRS=/layers/%s/conda-env-cache conda create --file /workspace/package-list.txt --prefix /layers/%s/conda-env --yes --quiet",
-					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"), strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
+				fmt.Sprintf(
+					"    Running CONDA_PKGS_DIRS=/layers/%s/conda-env-cache conda create --file /workspace/package-list.txt --prefix /layers/%s/conda-env --yes --quiet",
+					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"),
+					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"),
+				),
 				"    Running conda clean --packages --tarballs",
+				fmt.Sprintf(
+					"    Removing /layers/%s/conda-env/conda-meta/history",
+					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"),
+				),
 				MatchRegexp(`      Completed in (\d+m)?(\d+)(\.\d+)?(ms|s)`),
 				"",
 			))
@@ -148,6 +161,10 @@ func testLogging(t *testing.T, context spec.G, it spec.S) {
 				fmt.Sprintf("    Running CONDA_PKGS_DIRS=/layers/%s/conda-env-cache conda env update --prefix /layers/%s/conda-env --file /workspace/environment.yml",
 					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"), strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_")),
 				"    Running conda clean --packages --tarballs",
+				fmt.Sprintf(
+					"    Removing /layers/%s/conda-env/conda-meta/history",
+					strings.ReplaceAll(buildpackInfo.Buildpack.ID, "/", "_"),
+				),
 				MatchRegexp(`      Completed in (\d+m)?(\d+)(\.\d+)?(ms|s)`),
 				"",
 			))


### PR DESCRIPTION
## Summary

- This enables reproducible builds.

## Background

- This file is not reproducible as it contains timestamps, and it is not possible to configure conda to make this file reproducible.
- This file is used to allow conda users to revert to previous conda environments. This is of no value in the buildpack because we do not allow users to do this during the build phase, and the buildpack does not leverage this feature itself. As such, removing it has no known negative consequence.
- We have not explored whether removing this file would prevent someone from using this feature in an interactive session at launch time, but that is outside of the primary supported use-case of the buildpack.

## Use Cases

Enables reproducible builds.

Supersedes #189 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
